### PR TITLE
fix: polish resume scorecard builder, gauge, and Persian text

### DIFF
--- a/src/components/resume-review/copy-link-button.tsx
+++ b/src/components/resume-review/copy-link-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { CheckIcon, ClipboardDocumentIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
+import { useState } from "react";
+
+/** Primary accent CTA that copies the share link, with a brief copied state. */
+export function CopyLinkButton({
+	text,
+	label,
+	copiedLabel,
+	className,
+}: {
+	text: string;
+	label: string;
+	copiedLabel: string;
+	className?: string;
+}) {
+	const [copied, setCopied] = useState(false);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// Clipboard can be blocked (permissions, insecure context). Fail quietly.
+		}
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={() => void copy()}
+			className={clsx(
+				"inline-flex items-center justify-center gap-2 rounded-md px-5 py-2.5 text-sm font-semibold transition",
+				"bg-accent-600 text-white hover:bg-accent-700",
+				"dark:bg-accent-500 dark:text-zinc-950 dark:hover:bg-accent-400",
+				className,
+			)}
+		>
+			{copied ? (
+				<CheckIcon className="h-4 w-4" />
+			) : (
+				<ClipboardDocumentIcon className="h-4 w-4" />
+			)}
+			{copied ? copiedLabel : label}
+		</button>
+	);
+}

--- a/src/components/resume-review/flag-row.tsx
+++ b/src/components/resume-review/flag-row.tsx
@@ -21,10 +21,10 @@ export function FlagRow({
 			onClick={onToggle}
 			aria-pressed={flagged}
 			className={clsx(
-				"flex w-full items-start gap-3 rounded-xl p-3 text-start transition",
+				"flex w-full items-start gap-3 rounded-2xl p-4 text-start ring-1 transition",
 				flagged
-					? "bg-amber-500/10 ring-1 ring-amber-500/30"
-					: "hover:bg-zinc-900/5 dark:hover:bg-zinc-800/60",
+					? "bg-amber-500/10 ring-amber-500/30"
+					: "bg-surface ring-zinc-900/5 hover:-translate-y-0.5 hover:shadow-sm hover:shadow-zinc-900/5 dark:bg-zinc-800/30 dark:ring-zinc-800 dark:hover:bg-zinc-800/50",
 			)}
 		>
 			{flagged ? (
@@ -35,15 +35,15 @@ export function FlagRow({
 			<span className="min-w-0 flex-1">
 				<span
 					className={clsx(
-						"block text-sm font-medium",
+						"block text-sm font-semibold",
 						flagged
 							? "text-zinc-900 dark:text-zinc-100"
-							: "text-zinc-700 dark:text-zinc-300",
+							: "text-zinc-800 dark:text-zinc-100",
 					)}
 				>
 					{item.title}
 				</span>
-				<span className="mt-0.5 block text-xs text-zinc-500 dark:text-zinc-400">
+				<span className="mt-1 block text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
 					{item.question}
 				</span>
 			</span>

--- a/src/components/resume-review/review-builder.tsx
+++ b/src/components/resume-review/review-builder.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import clsx from "clsx";
 import { useState } from "react";
-import { CopyButton } from "@/components/copy-button";
 import { groupsFor, scoreForAll } from "@/data/resume-checklist";
 import { useChecklistStore } from "@/lib/checklist/use-checklist-store";
 import type { LanguageLocale } from "@/lib/languages/locale";
 import { checkedSlugs } from "@/lib/resume-review/checked-slugs";
 import { shareUrl } from "@/lib/resume-review/share-url";
+import { CopyLinkButton } from "./copy-link-button";
 import { FlagRow } from "./flag-row";
 import { ResumeScorecard } from "./resume-scorecard";
 import { ScoreGauge } from "./score-gauge";
@@ -52,40 +53,52 @@ export function ReviewBuilder({
 	return (
 		<div>
 			<div className="flex flex-col items-center text-center">
-				<h1 className="font-display text-3xl font-bold text-zinc-800 sm:text-4xl dark:text-zinc-100">
+				<h1
+					className={clsx(
+						locale === "fa-IR" ? "font-fa" : "font-display",
+						"text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100",
+					)}
+				>
 					{copy.builderTitle}
 				</h1>
-				<p className="mt-2 max-w-md text-zinc-600 dark:text-zinc-400">
+				<p className="mt-4 max-w-md text-zinc-600 dark:text-zinc-400">
 					{copy.builderIntro}
 				</p>
 			</div>
 
-			<div className="mt-8 flex flex-col items-center gap-4 rounded-3xl bg-surface p-6 ring-1 ring-zinc-900/10 sm:flex-row sm:justify-between dark:bg-zinc-800/40 dark:ring-zinc-700/50">
-				<div className="flex items-center gap-4">
-					<ScoreGauge score={score} locale={locale} className="h-20 w-20" />
-					<div className="text-start">
-						<p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-							{copy.projectedLabel}
-						</p>
-						<p className="text-sm text-zinc-600 dark:text-zinc-400">
-							{copy.flaggedCount(flagged.length)}
-						</p>
+			<div className="mt-10 rounded-3xl bg-surface p-6 ring-1 ring-zinc-900/10 sm:p-7 dark:bg-zinc-800/40 dark:ring-zinc-700/50">
+				<div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
+					<div className="flex items-center gap-4">
+						<ScoreGauge
+							score={score}
+							locale={locale}
+							showLabel={false}
+							className="h-24 w-24 shrink-0"
+						/>
+						<div className="text-start">
+							<p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+								{copy.projectedLabel}
+							</p>
+							<p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+								{copy.flaggedCount(flagged.length)}
+							</p>
+						</div>
 					</div>
-				</div>
-				<div className="flex flex-wrap items-center justify-center gap-2">
-					<CopyButton
-						text={shareUrl(locale, flagged)}
-						label={copy.copyLink}
-						copiedLabel={copy.copied}
-						className="bg-accent-500/10 text-accent-700 hover:bg-accent-500/20 dark:bg-accent-400/10 dark:text-accent-300"
-					/>
-					<button
-						type="button"
-						onClick={() => setPreview(true)}
-						className="rounded-md px-3 py-2 text-sm font-medium text-zinc-600 transition hover:bg-zinc-900/5 dark:text-zinc-300 dark:hover:bg-zinc-800/60"
-					>
-						{copy.previewCta}
-					</button>
+					<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
+						<CopyLinkButton
+							text={shareUrl(locale, flagged)}
+							label={copy.copyLink}
+							copiedLabel={copy.copied}
+							className="w-full sm:w-auto"
+						/>
+						<button
+							type="button"
+							onClick={() => setPreview(true)}
+							className="text-sm font-medium text-zinc-500 transition hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100"
+						>
+							{copy.previewCta}
+						</button>
+					</div>
 				</div>
 			</div>
 
@@ -101,13 +114,13 @@ export function ReviewBuilder({
 				</div>
 			)}
 
-			<div className="mt-10 space-y-8">
+			<div className="mt-12 space-y-10">
 				{groupsFor(locale).map((group) => (
 					<section key={group.id}>
-						<h2 className="mb-2 text-sm font-bold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+						<h2 className="mb-4 text-sm font-bold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
 							{group.title}
 						</h2>
-						<div className="space-y-1">
+						<div className="space-y-3">
 							{group.items.map((item) => (
 								<FlagRow
 									key={item.slug}

--- a/src/components/resume-review/score-bands.ts
+++ b/src/components/resume-review/score-bands.ts
@@ -13,7 +13,7 @@ interface IScoreBand {
 // the two lower bands. Final palette is settled in the screenshot critique.
 const BANDS: IScoreBand[] = [
 	{ min: 95, tone: "great", en: "Excellent", fa: "عالیه" },
-	{ min: 85, tone: "good", en: "Strong", fa: "قویه" },
+	{ min: 85, tone: "good", en: "Strong", fa: "خیلی خوبه" },
 	{ min: 70, tone: "pass", en: "Solid", fa: "خوبه" },
 	{ min: 50, tone: "warn", en: "Getting there", fa: "در حال پیشرفت" },
 	{ min: 0, tone: "danger", en: "Needs work", fa: "نیاز به کار داره" },

--- a/src/components/resume-review/score-gauge.tsx
+++ b/src/components/resume-review/score-gauge.tsx
@@ -9,18 +9,21 @@ const RADIUS = 52;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 /**
- * Circular score gauge. The arc draws in from empty on mount and animates
- * whenever the score changes; reduced motion snaps it. The number is always
- * the true score so no-JS and first paint read correctly.
+ * Circular score gauge. The number and band label live inside the SVG so they
+ * scale with the gauge at any size. The arc draws in from empty on mount and
+ * animates on score changes; reduced motion snaps it. The number is always the
+ * true score, so no-JS and first paint read correctly.
  */
 export function ScoreGauge({
 	score,
 	locale,
 	className,
+	showLabel = true,
 }: {
 	score: number;
 	locale: LanguageLocale;
 	className?: string;
+	showLabel?: boolean;
 }) {
 	const [shown, setShown] = useState(false);
 	useEffect(() => {
@@ -35,41 +38,57 @@ export function ScoreGauge({
 		<div className={clsx("relative", className)}>
 			<svg
 				viewBox="0 0 120 120"
-				className="h-full w-full -rotate-90"
+				className="h-full w-full"
 				role="img"
-				aria-label={`${score} out of 100`}
+				aria-label={`${score} / 100`}
 			>
 				<circle
 					cx="60"
 					cy="60"
 					r={RADIUS}
 					fill="none"
-					strokeWidth="9"
-					className="stroke-zinc-200 dark:stroke-zinc-700"
+					strokeWidth="8"
+					className="stroke-zinc-200 dark:stroke-zinc-700/60"
 				/>
 				<circle
 					cx="60"
 					cy="60"
 					r={RADIUS}
 					fill="none"
-					strokeWidth="9"
+					strokeWidth="8"
 					strokeLinecap="round"
 					strokeDasharray={CIRCUMFERENCE}
 					strokeDashoffset={offset}
+					transform="rotate(-90 60 60)"
 					className={clsx(
 						colors.stroke,
 						"transition-[stroke-dashoffset] duration-1000 ease-out motion-reduce:transition-none",
 					)}
 				/>
-			</svg>
-			<div className="absolute inset-0 flex flex-col items-center justify-center">
-				<span className={clsx("text-4xl font-bold tabular-nums", colors.text)}>
+				<text
+					x="60"
+					y={showLabel ? 54 : 60}
+					textAnchor="middle"
+					dominantBaseline="central"
+					fill="currentColor"
+					fontSize="30"
+					className={clsx("font-bold tabular-nums", colors.text)}
+				>
 					{score.toLocaleString(locale)}
-				</span>
-				<span className="text-[0.7rem] font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-					{bandLabel(score, locale)}
-				</span>
-			</div>
+				</text>
+				{showLabel && (
+					<text
+						x="60"
+						y="78"
+						textAnchor="middle"
+						dominantBaseline="central"
+						fontSize="10"
+						className="fill-zinc-500 font-semibold tracking-wide dark:fill-zinc-400"
+					>
+						{bandLabel(score, locale)}
+					</text>
+				)}
+			</svg>
 		</div>
 	);
 }


### PR DESCRIPTION
Follow-up polish to the resume scorecard (the base feature shipped in #123, now on `main`).

Addresses feedback on the Persian page and the builder UI:

- **Persian heading font**: the heading used the Latin display font (Newsreader), which has no Persian glyphs and fell back to a serif. It now renders in **Vazirmatn** (locale-aware `font-fa` vs `font-display`).
- **Score gauge**: redesigned so the number and band label live **inside the SVG** and scale cleanly at any size; softer track and refined stroke. Also added a `showLabel` prop (off for the small builder gauge).
- **Band phrasing**: Persian "good" band label قویه → **خیلی خوبه**.
- **Builder list**: every row is now a **card with generous spacing** (was cramped at `space-y-1`), so it reads like a mobile app.
- **Top box + heading**: larger heading, cleaner score box, and a prominent solid-accent **"Copy review link"** CTA (new `CopyLinkButton` so the accent colour isn't lost to a base-class Tailwind conflict).

The resume guide already links to the scorecard via the existing "Open the resume scorecard" CTA in its Final Checklist section.

Verified: `biome`, `check-types`, and `next build` all pass; reviewed across English/Persian and light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCSHeur6r52f7oMFK5Xhim

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCSHeur6r52f7oMFK5Xhim)_