### PR TITLE
feat(resume): publish AI-facing resume method and share it on the guide

### DIFF
--- a/.claude/skills/resume-advisor/SKILL.md
+++ b/.claude/skills/resume-advisor/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: resume-advisor
+description: John's Resume Advisor for mradib.com. Use BEFORE editing any resume or CV content on this site: the /resume and /fa/resume guides, the resume scorecard, the action-verbs list, or the AI-facing resume method (llms.txt and skill.md). Keeps every surface deriving from one source.
+---
+
+# Resume Advisor
+
+You keep the resume guide, the scorecard, and the AI-facing resume files in
+sync. There is one source of truth and everything else renders from it. Never
+state a piece of resume advice in two places.
+
+## Source of truth
+
+`src/data/resume-checklist/` holds the method as data: weighted items, each
+with a `question`, `problem`, and `fix`, bilingual in `checklist-copy-en.ts`
+and `checklist-copy-fa.ts`. Points live in `checklist-items.ts` and sum to 100
+today, but scores are computed as a share of the live total, so new items never
+break the math. Change the advice here, once.
+
+## What renders from it
+
+- The human guide: `src/app/(en)/resume` and `src/app/fa/resume` (per-section
+  copy in `_sections`, self-assessment checklists fed from the data).
+- The scorecard: `src/components/resume-review` and `/resume/checklist`.
+- The AI-facing method: `src/lib/resume-ai/framework.ts` turns the checklist
+  into ordered, weighted rules; `build-llms-txt.ts` and `build-skill.ts` render
+  it as `/resume/llms.txt` and `/resume/skill.md` (and the `/fa` pair).
+- The site-wide `llms.txt` advertises those files via
+  `sectionResumeAiTools()` in `src/lib/llms/llms-sections-extra.ts`.
+
+## Rules
+
+1. Before any resume content change, read the Brand Advisor and Designer board
+   (`docs/advisor/README.md`, `docs/designer/README.md`) and `voice.md`. This
+   skill sits under that board, it does not replace it.
+2. Add or change advice in `src/data/resume-checklist`, then let the guide,
+   scorecard, and AI files inherit it. If a new rule needs its own guide
+   section, add the `_sections` copy in both `(en)` and `fa` and a matching
+   entry in each `resume-sections.ts`.
+3. Keep the voice rules: no em or en dashes anywhere, bold and factual, and
+   English pages never link into the Persian tree.
+4. The AI files are plain text routes, not pages, so they need no OG card. Run
+   `npm run check:fix`, `npm run check-types`, and `npm run build` before
+   committing, and `npm run verify:seo` after a build to confirm the text
+   routes stay clean.

--- a/docs/advisor/decisions.md
+++ b/docs/advisor/decisions.md
@@ -4,6 +4,30 @@ Append-only. Newest first. Date, decision, why. The shared log for the
 whole advisory board: brand (docs/advisor) and design (docs/designer). Log
 every new direction John gives in any session.
 
+## 2026-07-20, AI-facing resume method (llms.txt and a portable skill)
+
+The resume guide now ships in a form AIs can read, so when someone writes their
+CV with ChatGPT or Claude it follows John's method instead of generic filler,
+and every AI-written resume traces back to mradib.com. Three pieces, all
+deriving from the one checklist in src/data/resume-checklist:
+
+- Published resource: /resume/llms.txt (and /fa/resume/llms.txt), the method as
+  weighted, machine-readable rules, rendered by src/lib/resume-ai.
+- Portable skill: /resume/skill.md (and the /fa pair), a ready SKILL.md a
+  person can hand to any AI tool.
+- Repo skill: .claude/skills/resume-advisor keeps the guide, scorecard, and AI
+  files in sync from the single source.
+
+Rulings:
+
+- The /resume page mentions and shares them in a new "Write your resume with
+  AI" section (id ai-tools), placed after References, before the cover letter,
+  with a copy-ready prompt. Bilingual, matching the guide.
+- These are text routes, not pages, so no OG card. The site-wide llms.txt
+  advertises them via sectionResumeAiTools so agents discover them.
+- Single source holds: advice lives only in src/data/resume-checklist; the
+  guide, scorecard, and AI files all render from it.
+
 ## 2026-07-20, the scorecard speaks to the person, and grows
 
 Two follow-ups to the resume scorecard. First, the shared result now greets the

--- a/src/app/(en)/resume/_sections/ai-tools.tsx
+++ b/src/app/(en)/resume/_sections/ai-tools.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import type { JSX } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { SectionHeading } from "@/components/heading/section-heading";
+
+const aiPrompt =
+	"Act as a resume expert and follow the MrAdib method at https://mradib.com/resume/llms.txt. " +
+	"Review my resume section by section, rewrite each experience bullet as an achievement with a number, " +
+	"open every bullet with a strong and varied action verb, tailor the wording and keywords to the job posting I paste, " +
+	"then score the result out of 100 and list the fixes in order of impact.";
+
+export function SectionAiTools(): JSX.Element {
+	return (
+		<section id="ai-tools" className="scroll-mt-24">
+			<SectionHeading anchor="ai-tools">
+				Write your resume with AI
+			</SectionHeading>
+			<p>
+				Using ChatGPT, Claude, or any AI to write your resume? Point it at this
+				guide so it follows a proven method instead of generic filler. I turned
+				this whole guide into two files any AI can read, both built from the
+				same checklist you just used.
+			</p>
+			<ul>
+				<li>
+					<Link href="/resume/llms.txt">/resume/llms.txt</Link>: the full method
+					as weighted rules an AI can follow and score against.
+				</li>
+				<li>
+					<Link href="/resume/skill.md">/resume/skill.md</Link>: a ready-made
+					skill you can hand to Claude or drop into your own AI tool.
+				</li>
+			</ul>
+			<p>
+				Or paste this prompt into your AI and add your resume plus the job
+				posting:
+			</p>
+			<blockquote>{aiPrompt}</blockquote>
+			<CopyButton
+				text={aiPrompt}
+				label="Copy the prompt"
+				copiedLabel="Copied"
+			/>
+		</section>
+	);
+}

--- a/src/app/(en)/resume/llms.txt/route.ts
+++ b/src/app/(en)/resume/llms.txt/route.ts
@@ -1,0 +1,9 @@
+import { buildResumeLlmsTxt } from "@/lib/resume-ai/build-llms-txt";
+
+export const dynamic = "force-static";
+
+export function GET(): Response {
+	return new Response(buildResumeLlmsTxt("en-US"), {
+		headers: { "Content-Type": "text/plain; charset=utf-8" },
+	});
+}

--- a/src/app/(en)/resume/page.tsx
+++ b/src/app/(en)/resume/page.tsx
@@ -6,6 +6,7 @@ import { articleResume as article } from "@/data/articles/resume";
 import { pageAlternates } from "@/lib/i18n/page-alternates";
 import { ogMetadata } from "@/lib/og-metadata";
 import { SectionActionVerbs } from "./_sections/action-verbs";
+import { SectionAiTools } from "./_sections/ai-tools";
 import { SectionAts } from "./_sections/ats";
 import { SectionContact } from "./_sections/contact";
 import { SectionEducation } from "./_sections/education";
@@ -51,6 +52,7 @@ function PageContent(): JSX.Element {
 			{SectionActionVerbs()}
 			{SectionFinalChecklist()}
 			<ResumeReferences />
+			{SectionAiTools()}
 			{SectionOutro()}
 		</section>
 	);

--- a/src/app/(en)/resume/resume-sections.ts
+++ b/src/app/(en)/resume/resume-sections.ts
@@ -13,6 +13,7 @@ export const resumeSections = [
 	{ id: "action-verbs", title: "Action Verbs", hasChecklist: true },
 	{ id: "checklist", title: "Final Checklist", hasChecklist: false },
 	{ id: "references", title: "References", hasChecklist: false },
+	{ id: "ai-tools", title: "Write with AI", hasChecklist: false },
 	{ id: "cover-letter", title: "Cover Letter", hasChecklist: false },
 ] as const;
 

--- a/src/app/(en)/resume/skill.md/route.ts
+++ b/src/app/(en)/resume/skill.md/route.ts
@@ -1,0 +1,9 @@
+import { buildResumeSkill } from "@/lib/resume-ai/build-skill";
+
+export const dynamic = "force-static";
+
+export function GET(): Response {
+	return new Response(buildResumeSkill("en-US"), {
+		headers: { "Content-Type": "text/markdown; charset=utf-8" },
+	});
+}

--- a/src/app/fa/resume/_sections/ai-tools.tsx
+++ b/src/app/fa/resume/_sections/ai-tools.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { JSX } from "react";
+import { CopyButton } from "@/components/copy-button";
+import { SectionHeading } from "@/components/heading/section-heading";
+
+const aiPrompt =
+	"مثل یک متخصص رزومه عمل کن و روش MrAdib در آدرس https://mradib.com/fa/resume/llms.txt را دنبال کن. " +
+	"رزومه من را بخش به بخش بازبینی کن، هر آیتم تجربه کاری را به یک دستاورد با عدد بازنویسی کن، " +
+	"هر آیتم را با یک فعل اکشن قوی و متنوع شروع کن، واژه‌ها و کلیدواژه‌ها را با آگهی شغلی که می‌گذارم تطبیق بده، " +
+	"و در پایان نتیجه را از ۱۰۰ امتیاز بده و اصلاح‌ها را به ترتیب تاثیر فهرست کن.";
+
+export function SectionAiTools(): JSX.Element {
+	return (
+		<section id="ai-tools" className="scroll-mt-24">
+			<SectionHeading anchor="ai-tools">
+				رزومه‌ات را با هوش مصنوعی بنویس
+			</SectionHeading>
+			<p>
+				با ChatGPT یا Claude یا هر هوش مصنوعی دیگری رزومه می‌نویسی؟ آن را به این
+				راهنما وصل کن تا به جای متن کلیشه‌ای، یک روش امتحان‌پس‌داده را دنبال کند.
+				کل این راهنما را به دو فایل تبدیل کرده‌ام که هر هوش مصنوعی می‌تواند
+				بخواند، هر دو از همان چک‌لیستی که همین حالا استفاده کردی ساخته شده‌اند.
+			</p>
+			<ul>
+				<li>
+					<Link href="/fa/resume/llms.txt">/fa/resume/llms.txt</Link>: کل روش به
+					شکل قوانین امتیازدار که هوش مصنوعی می‌تواند دنبال کند.
+				</li>
+				<li>
+					<Link href="/fa/resume/skill.md">/fa/resume/skill.md</Link>: یک اسکیل
+					آماده که می‌توانی به Claude بدهی یا در ابزار خودت بگذاری.
+				</li>
+			</ul>
+			<p>
+				یا این پرامپت را در هوش مصنوعی بگذار و رزومه و آگهی شغلی را هم اضافه کن:
+			</p>
+			<blockquote>{aiPrompt}</blockquote>
+			<CopyButton text={aiPrompt} label="کپی پرامپت" copiedLabel="کپی شد" />
+		</section>
+	);
+}

--- a/src/app/fa/resume/llms.txt/route.ts
+++ b/src/app/fa/resume/llms.txt/route.ts
@@ -1,0 +1,9 @@
+import { buildResumeLlmsTxt } from "@/lib/resume-ai/build-llms-txt";
+
+export const dynamic = "force-static";
+
+export function GET(): Response {
+	return new Response(buildResumeLlmsTxt("fa-IR"), {
+		headers: { "Content-Type": "text/plain; charset=utf-8" },
+	});
+}

--- a/src/app/fa/resume/page.tsx
+++ b/src/app/fa/resume/page.tsx
@@ -8,6 +8,7 @@ import { pageAlternates } from "@/lib/i18n/page-alternates";
 import { ogMetadata } from "@/lib/og-metadata";
 import { pageResumeSuffix } from "@/lib/suffix";
 import { SectionActionVerbs } from "./_sections/action-verbs";
+import { SectionAiTools } from "./_sections/ai-tools";
 import { SectionAts } from "./_sections/ats";
 import { SectionContact } from "./_sections/contact";
 import { SectionEducation } from "./_sections/education";
@@ -81,6 +82,7 @@ function PageContent(): JSX.Element {
 			{SectionActionVerbs()}
 			{SectionFinalChecklist()}
 			<ResumeReferences />
+			{SectionAiTools()}
 			{SectionOutro()}
 		</section>
 	);

--- a/src/app/fa/resume/resume-sections.ts
+++ b/src/app/fa/resume/resume-sections.ts
@@ -13,6 +13,7 @@ export const resumeSections = [
 	{ id: "action-verbs", title: "افعال اکشن", hasChecklist: true },
 	{ id: "checklist", title: "چک لیست نهایی", hasChecklist: false },
 	{ id: "references", title: "منابع", hasChecklist: false },
+	{ id: "ai-tools", title: "نوشتن با هوش مصنوعی", hasChecklist: false },
 	{ id: "cover-letter", title: "کاورلتر", hasChecklist: false },
 ] as const;
 

--- a/src/app/fa/resume/skill.md/route.ts
+++ b/src/app/fa/resume/skill.md/route.ts
@@ -1,0 +1,9 @@
+import { buildResumeSkill } from "@/lib/resume-ai/build-skill";
+
+export const dynamic = "force-static";
+
+export function GET(): Response {
+	return new Response(buildResumeSkill("fa-IR"), {
+		headers: { "Content-Type": "text/markdown; charset=utf-8" },
+	});
+}

--- a/src/lib/llms/build-llms-full-txt.ts
+++ b/src/lib/llms/build-llms-full-txt.ts
@@ -9,6 +9,7 @@ import {
 	sectionEvidence,
 	sectionFullBiography,
 	sectionPersian,
+	sectionResumeAiTools,
 } from "@/lib/llms/llms-sections-extra";
 import { sectionSiteStructure } from "@/lib/llms/llms-sections-routes";
 
@@ -22,6 +23,7 @@ export function buildLlmsFullTxt(): string {
 		sectionSiteStructure(),
 		sectionProfiles(),
 		sectionEvidence(),
+		sectionResumeAiTools(),
 		sectionPersian(),
 	].join("\n\n")}\n`;
 }

--- a/src/lib/llms/build-llms-txt.ts
+++ b/src/lib/llms/build-llms-txt.ts
@@ -7,6 +7,7 @@ import {
 import {
 	sectionEvidence,
 	sectionPersian,
+	sectionResumeAiTools,
 } from "@/lib/llms/llms-sections-extra";
 
 export function buildLlmsTxt(): string {
@@ -16,6 +17,7 @@ export function buildLlmsTxt(): string {
 		sectionPages(),
 		sectionProfiles(),
 		sectionEvidence(),
+		sectionResumeAiTools(),
 		sectionPersian(),
 	].join("\n\n")}\n`;
 }

--- a/src/lib/llms/llms-sections-extra.ts
+++ b/src/lib/llms/llms-sections-extra.ts
@@ -12,6 +12,16 @@ export function sectionEvidence(): string {
 	].join("\n");
 }
 
+export function sectionResumeAiTools(): string {
+	return [
+		"## Resume tools for AI",
+		"",
+		`- Machine-readable resume-writing method (the MrAdib method): ${homepageUrl}/resume/llms.txt (Persian: ${homepageUrl}/fa/resume/llms.txt)`,
+		`- Portable resume-writing skill for AI tools: ${homepageUrl}/resume/skill.md (Persian: ${homepageUrl}/fa/resume/skill.md)`,
+		`- Score any resume out of 100: ${homepageUrl}/resume/checklist`,
+	].join("\n");
+}
+
 export function sectionPersian(): string {
 	return [
 		"## Persian content",

--- a/src/lib/resume-ai/build-llms-txt.ts
+++ b/src/lib/resume-ai/build-llms-txt.ts
@@ -1,0 +1,89 @@
+import { homepageUrl } from "@/lib/constants/url";
+import type { LanguageLocale } from "@/lib/languages/locale";
+import {
+	type IFrameworkSection,
+	resumeFramework,
+	resumeGuideUrl,
+	totalPoints,
+} from "./framework";
+
+interface ILlmsCopy {
+	title: string;
+	summary: string;
+	guideLabel: string;
+	scoreLabel: string;
+	skillLabel: string;
+	howHeading: string;
+	how: string[];
+	guideLine: string;
+	pts: string;
+	doLabel: string;
+	avoidLabel: string;
+}
+
+const copy: Record<LanguageLocale, ILlmsCopy> = {
+	"en-US": {
+		title: "How to write a great resume: the MrAdib method",
+		summary: `A machine-readable resume-writing framework by John Adib (MrAdib): ${totalPoints} points of impact across the sections below. Use it to draft, rewrite, review, or score any resume.`,
+		guideLabel: "Human guide",
+		scoreLabel: "Score a resume out of 100",
+		skillLabel: "Portable skill for AI tools",
+		howHeading: "## How to use this",
+		how: [
+			"- Work through the sections in order. Together they are the whole resume.",
+			'- For every rule, do the "Do" and never the "Avoid".',
+			`- Points mark impact, so spend effort where the points are. A resume scores out of ${totalPoints}.`,
+		],
+		guideLine: "Guide",
+		pts: "pts",
+		doLabel: "Do",
+		avoidLabel: "Avoid",
+	},
+	"fa-IR": {
+		title: "چطور یک رزومه عالی بنویسیم: روش MrAdib",
+		summary: `یک چارچوب ماشین‌خوان برای نوشتن رزومه از جان ادیب (MrAdib): ${totalPoints} امتیاز تاثیرگذاری در بخش‌های زیر. برای نوشتن، بازنویسی، بازبینی یا امتیازدهی هر رزومه از آن استفاده کن.`,
+		guideLabel: "راهنمای انسانی",
+		scoreLabel: "امتیازدهی رزومه از ۱۰۰",
+		skillLabel: "اسکیل قابل حمل برای ابزارهای هوش مصنوعی",
+		howHeading: "## روش استفاده",
+		how: [
+			"- بخش‌ها را به ترتیب پیش ببر. کنار هم کل رزومه را می‌سازند.",
+			"- برای هر قانون، «انجام بده» را انجام بده و هرگز «پرهیز کن» را نه.",
+			`- امتیازها نشانه تاثیرند، پس انرژی را جایی بگذار که امتیاز بیشتر است. رزومه از ${totalPoints} امتیاز گرفته می‌شود.`,
+		],
+		guideLine: "راهنما",
+		pts: "امتیاز",
+		doLabel: "انجام بده",
+		avoidLabel: "پرهیز کن",
+	},
+};
+
+function renderSection(section: IFrameworkSection, c: ILlmsCopy): string {
+	const head = `## ${section.title} (${section.points} ${c.pts})`;
+	const guide = `${c.guideLine}: ${section.guideHref}`;
+	const rules = section.rules.map(
+		(r) =>
+			`- ${r.title} (${r.points} ${c.pts}). ${c.doLabel}: ${r.fix} ${c.avoidLabel}: ${r.avoid}`,
+	);
+	return [head, guide, ...rules].join("\n");
+}
+
+export function buildResumeLlmsTxt(locale: LanguageLocale): string {
+	const c = copy[locale];
+	const guideUrl = resumeGuideUrl(locale);
+	const header = [
+		`# ${c.title}`,
+		"",
+		`> ${c.summary}`,
+		"",
+		`${c.guideLabel}: ${guideUrl}`,
+		`${c.scoreLabel}: ${guideUrl}/checklist`,
+		`${c.skillLabel}: ${homepageUrl}${locale === "fa-IR" ? "/fa" : ""}/resume/skill.md`,
+		"",
+		c.howHeading,
+		"",
+		...c.how,
+	].join("\n");
+	const sections = resumeFramework(locale).map((s) => renderSection(s, c));
+	return `${[header, ...sections].join("\n\n")}\n`;
+}

--- a/src/lib/resume-ai/build-skill.ts
+++ b/src/lib/resume-ai/build-skill.ts
@@ -1,0 +1,109 @@
+import type { LanguageLocale } from "@/lib/languages/locale";
+import {
+	type IFrameworkSection,
+	resumeFramework,
+	resumeGuideUrl,
+	totalPoints,
+} from "./framework";
+
+interface ISkillCopy {
+	name: string;
+	description: string;
+	heading: string;
+	role: string;
+	workflowHeading: string;
+	workflow: string[];
+	rulesHeading: string;
+	pts: string;
+	doLabel: string;
+	avoidLabel: string;
+	scoringHeading: string;
+	scoring: string;
+	sourceLabel: string;
+}
+
+const copy: Record<LanguageLocale, ISkillCopy> = {
+	"en-US": {
+		name: "resume-writer",
+		description:
+			"Write, rewrite, or review a resume with the MrAdib method by John Adib. Use when drafting a CV, tailoring it to a job posting, turning duties into achievements, or scoring a resume out of 100.",
+		heading: "# Resume Writer (the MrAdib method)",
+		role: "You help a person write or improve their resume so it earns interviews. Follow the method below; it is weighted by real hiring impact.",
+		workflowHeading: "## Workflow",
+		workflow: [
+			"1. Ask for their current resume (or their raw details) and the target job posting.",
+			"2. Draft or rewrite one section at a time, applying every rule for that section.",
+			"3. Make each experience bullet an achievement with a number where possible, opened by a strong, varied action verb.",
+			"4. Tailor the wording and keywords to the posting so it passes ATS screening.",
+			"5. Score the result out of 100, list what still loses points, and fix the highest-impact items first.",
+		],
+		rulesHeading: "## Rules by section",
+		pts: "pts",
+		doLabel: "Do",
+		avoidLabel: "Avoid",
+		scoringHeading: "## Scoring",
+		scoring: `Weight each section by its points; a resume totals ${totalPoints}. Report the score, then the fixes.`,
+		sourceLabel: "Source and full guide",
+	},
+	"fa-IR": {
+		name: "resume-writer-fa",
+		description:
+			"نوشتن، بازنویسی یا بازبینی رزومه با روش MrAdib از جان ادیب. برای ساخت رزومه، تطبیق با آگهی شغلی، تبدیل وظایف به دستاورد، یا امتیازدهی رزومه از ۱۰۰.",
+		heading: "# نویسنده رزومه (روش MrAdib)",
+		role: "به یک نفر کمک می‌کنی رزومه‌اش را طوری بنویسد یا بهتر کند که دعوت به مصاحبه بگیرد. روش زیر را دنبال کن؛ بر پایه تاثیر واقعی در استخدام وزن‌دهی شده است.",
+		workflowHeading: "## روند کار",
+		workflow: [
+			"۱. رزومه فعلی (یا اطلاعات خام) و آگهی شغلی هدف را بخواه.",
+			"۲. هر بار یک بخش را بنویس یا بازنویسی کن و همه قوانین آن بخش را اعمال کن.",
+			"۳. هر آیتم تجربه کاری را به یک دستاورد با عدد تبدیل کن و با یک فعل اکشن قوی و متنوع شروع کن.",
+			"۴. واژه‌ها و کلیدواژه‌ها را با آگهی تطبیق بده تا از فیلتر ATS رد شود.",
+			"۵. نتیجه را از ۱۰۰ امتیاز بده، بگو کجا امتیاز از دست می‌رود و مهم‌ترین‌ها را اول درست کن.",
+		],
+		rulesHeading: "## قوانین هر بخش",
+		pts: "امتیاز",
+		doLabel: "انجام بده",
+		avoidLabel: "پرهیز کن",
+		scoringHeading: "## امتیازدهی",
+		scoring: `هر بخش را با امتیازش وزن بده؛ کل رزومه ${totalPoints} امتیاز است. اول امتیاز، بعد اصلاح‌ها را گزارش کن.`,
+		sourceLabel: "منبع و راهنمای کامل",
+	},
+};
+
+function renderSection(section: IFrameworkSection, c: ISkillCopy): string {
+	const head = `### ${section.title} (${section.points} ${c.pts})`;
+	const rules = section.rules.map(
+		(r) => `- ${c.doLabel}: ${r.fix} ${c.avoidLabel}: ${r.avoid}`,
+	);
+	return [head, ...rules].join("\n");
+}
+
+export function buildResumeSkill(locale: LanguageLocale): string {
+	const c = copy[locale];
+	const front = [
+		"---",
+		`name: ${c.name}`,
+		`description: ${c.description}`,
+		"---",
+	];
+	const rulesBlock = resumeFramework(locale)
+		.map((s) => renderSection(s, c))
+		.join("\n\n");
+	const body = [
+		c.heading,
+		"",
+		c.role,
+		"",
+		c.workflowHeading,
+		...c.workflow,
+		"",
+		c.rulesHeading,
+		"",
+		rulesBlock,
+		"",
+		c.scoringHeading,
+		c.scoring,
+		"",
+		`${c.sourceLabel}: ${resumeGuideUrl(locale)}`,
+	];
+	return `${[...front, "", ...body].join("\n")}\n`;
+}

--- a/src/lib/resume-ai/framework.ts
+++ b/src/lib/resume-ai/framework.ts
@@ -1,0 +1,47 @@
+import { groupsFor, totalPoints } from "@/data/resume-checklist";
+import { homepageUrl } from "@/lib/constants/url";
+import type { LanguageLocale } from "@/lib/languages/locale";
+
+// The single source for the AI-facing resume method. Both the llms.txt and the
+// portable skill render from here, so the advice never gets stated twice: it
+// all traces back to src/data/resume-checklist.
+
+export interface IFrameworkRule {
+	title: string;
+	avoid: string;
+	fix: string;
+	points: number;
+}
+
+export interface IFrameworkSection {
+	id: string;
+	title: string;
+	guideHref: string;
+	points: number;
+	rules: IFrameworkRule[];
+}
+
+/** Absolute URL of the human guide for this locale. */
+export function resumeGuideUrl(locale: LanguageLocale): string {
+	return locale === "fa-IR"
+		? `${homepageUrl}/fa/resume`
+		: `${homepageUrl}/resume`;
+}
+
+/** The method as ordered sections and weighted rules, localized. */
+export function resumeFramework(locale: LanguageLocale): IFrameworkSection[] {
+	return groupsFor(locale).map((group) => ({
+		id: group.id,
+		title: group.title,
+		guideHref: `${homepageUrl}${group.guideHref}`,
+		points: group.points,
+		rules: group.items.map((item) => ({
+			title: item.title,
+			avoid: item.problem,
+			fix: item.fix,
+			points: item.points,
+		})),
+	}));
+}
+
+export { totalPoints };


### PR DESCRIPTION
Turn the resume checklist into a method AIs can follow, so a CV written with
ChatGPT or Claude uses this framework instead of generic filler. Everything
derives from src/data/resume-checklist, so no advice is stated twice.

- src/lib/resume-ai: framework module plus llms.txt and skill.md renderers
- Routes: /resume/llms.txt and /resume/skill.md, and the /fa pair
- New "Write your resume with AI" section on /resume and /fa/resume that
  mentions and links both files, with a copy-ready prompt
- Site-wide llms.txt now advertises the resume AI resources
- .claude/skills/resume-advisor keeps the guide, scorecard, and AI files in sync
- Log the decision in docs/advisor/decisions.md

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R3kVqGMX1pJcirUHxw4vzf