### PR TITLE
feat(resume): thumbs up/down grading with an amber caution middle

### DIFF
--- a/docs/advisor/decisions.md
+++ b/docs/advisor/decisions.md
@@ -4,6 +4,14 @@ Append-only. Newest first. Date, decision, why. The shared log for the
 whole advisory board: brand (docs/advisor) and design (docs/designer). Log
 every new direction John gives in any session.
 
+## 2026-07-20, the grade emojis are a traffic light
+
+John swapped the grade emojis to thumbs at the ends and a clearer middle: good is
+a thumbs up, problem a thumbs down, and needs work an amber warning triangle, the
+caution light between them (unset stays a neutral dash). It reads as a green, amber,
+red traffic light, and the amber warning matches the needs-work colour used
+elsewhere. Only the glyphs changed; the codes, scoring, and cycle are the same.
+
 ## 2026-07-20, grading is one tappable emoji, unset by default
 
 John's next pass: the segmented control repeated the same three labels on every

--- a/src/components/resume-review/grade-emoji.ts
+++ b/src/components/resume-review/grade-emoji.ts
@@ -1,13 +1,14 @@
-/** The emoji for each grade: unset (choose), good, needs work, problem. */
+/** The emoji for each grade: unset (choose), good, needs work, problem. Good and
+ * problem are thumbs; needs work is an amber caution, the traffic-light middle. */
 export function gradeEmoji(code: number): string {
 	if (code === 1) {
-		return "🙂";
+		return "👍";
 	}
 	if (code === 2) {
-		return "😐";
+		return "⚠️";
 	}
 	if (code === 3) {
-		return "🙁";
+		return "👎";
 	}
 	return "➖";
 }


### PR DESCRIPTION
## Summary

Follow-up to #129 (merged). Swaps the grade emojis in the resume reviewer to read as a traffic light:

- 👍 Good
- ⚠️ Needs work (amber caution, the middle light, matching the needs-work colour)
- 👎 Problem
- ➖ unset (default, not scored)

Only the glyphs changed in `grade-emoji.ts`; the codes, scoring, tap-to-cycle, and share codec are all unchanged. The candidate result shows the same emoji on each issue.

## Verification

- `check:fix`, `check-types`, `build`, and `verify:seo` all pass.
- Screenshotted the builder (legend + graded rows) in light and dark; all four emojis render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCSHeur6r52f7oMFK5Xhim

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCSHeur6r52f7oMFK5Xhim)_